### PR TITLE
Change version of pyinstaller to 5.5 from 5.0.1 for Amazon Linux 2023…

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -50,5 +50,4 @@ if($LASTEXITCODE -ne 0) {
     throw "**ERROR**: pyinstaller failed, binary was not created"
 }
 
-Remove-Item .\dist\$Filename\pyinstaller-5.0.1.dist-info -Recurse
 Write-Output "*** Success: Executable saved at dist\$Filename ***"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,7 +7,7 @@ Jinja2==3.1.2
 MarkupSafe==2.1.1
 packaging==21.3
 progressbar33==2.4
-pyinstaller==5.0.1
+pyinstaller==5.5
 pyinstaller-hooks-contrib==2022.4
 pyparsing==3.0.9
 requests==2.28.1


### PR DESCRIPTION
… running python 3.11

#### Description of change
[X]: # Using Porting Advisor on Amazon Linux 2023 on AWS Graviton (c6g) but build.sh fails

#### Issue
[X]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)

#### PR reviewer notes
[X]: # 14

Changing pyinstaller to 5.5 works on AL 2023 and Ubuntu 22.04

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.