### PR TITLE
Add Dockerfile for build a self-containing container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM python:3.11.3-alpine3.17 as builder
+ARG version=17.0.7.7.1
+
+RUN apk add --no-cache bash procps curl tar binutils
+
+# Install Amazon Corretto 17, src: https://github.com/corretto/corretto-docker/blob/ef6f5a60332e35d72fee88ce86e195f62efa6ab4/17/jdk/alpine/3.17/Dockerfile
+
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-17=$version-r0
+
+ENV LANG C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+# Install Maven 3.9.2, src: https://github.com/carlossg/docker-maven/blob/5f8a86d716eb63fb5a1ef03e5cb743f5df4ffa0a/eclipse-temurin-17-alpine/Dockerfile
+
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.2-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.2-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.2-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.2
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+WORKDIR /tmp
+COPY . .
+RUN ./build.sh
+
+# Use Amazon Corretto as runtime
+FROM amazoncorretto:17.0.7-alpine3.17 as runtime
+WORKDIR /opt
+COPY --from=builder /tmp/dist/porting-advisor-linux-x86_64 /opt/
+ENTRYPOINT ["./porting-advisor-linux-x86_64"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,26 @@
-FROM python:3.11.3-alpine3.17 as builder
-ARG version=17.0.7.7.1
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.0.20230503.0 as builder
+# Should I lock the version here?
+# ARG JAVA_VER=1:17.0.7+7-1.amzn2023.1
+# ARG MAVEN_VER=1:3.8.4-3.amzn2023.0.4
+# ARG PYTHON_VER=3.11.2-2.amzn2023.0.6
+# ARG PIP_VER=22.3.1-2.amzn2023.0.2
+# RUN yum install java-17-amazon-corretto-${JAVA_VER} python3.11-${PYTHON_VER} python3.11-pip-${PIP_VER} maven-${MAVEN_VER} -y
 
-RUN apk add --no-cache bash procps curl tar binutils
+RUN yum install java-17-amazon-corretto python3.11 python3.11-pip maven binutils -y && \
+    yum clean all
 
-# Install Amazon Corretto 17, src: https://github.com/corretto/corretto-docker/blob/ef6f5a60332e35d72fee88ce86e195f62efa6ab4/17/jdk/alpine/3.17/Dockerfile
+ENV JAVA_HOME=/usr/lib/jvm/java
+ENV MAVEN_HOME=/usr/share/maven
 
-RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
-    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
-    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
-    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
-    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
-    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
-    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
-    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0
-
-ENV LANG C.UTF-8
-
-ENV JAVA_HOME=/usr/lib/jvm/default-jvm
-ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-# Install Maven 3.9.2, src: https://github.com/carlossg/docker-maven/blob/5f8a86d716eb63fb5a1ef03e5cb743f5df4ffa0a/eclipse-temurin-17-alpine/Dockerfile
-
-ENV MAVEN_HOME /usr/share/maven
-
-COPY --from=maven:3.9.2-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
-COPY --from=maven:3.9.2-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY --from=maven:3.9.2-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
-
-RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
-
-ARG MAVEN_VERSION=3.9.2
-ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-WORKDIR /tmp
 COPY . .
-RUN ./build.sh
+RUN /usr/bin/python3.11 -m venv .venv && \
+    source .venv/bin/activate && \
+    python3 -m pip install -r requirements-build.txt && \
+    ./build.sh
+
+RUN mv dist/porting-advisor-linux-$(uname -m) /opt/porting-advisor
 
 # Use Amazon Corretto as runtime
-FROM amazoncorretto:17.0.7-alpine3.17 as runtime
-WORKDIR /opt
-COPY --from=builder /tmp/dist/porting-advisor-linux-x86_64 /opt/
-ENTRYPOINT ["./porting-advisor-linux-x86_64"]
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:17.0.7-al2023 as runtime
+COPY --from=builder /opt/porting-advisor /usr/bin/porting-advisor
+ENTRYPOINT ["/usr/bin/porting-advisor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.0.20230503.0 as builder
-# Should I lock the version here?
-# ARG JAVA_VER=1:17.0.7+7-1.amzn2023.1
-# ARG MAVEN_VER=1:3.8.4-3.amzn2023.0.4
-# ARG PYTHON_VER=3.11.2-2.amzn2023.0.6
-# ARG PIP_VER=22.3.1-2.amzn2023.0.2
-# RUN yum install java-17-amazon-corretto-${JAVA_VER} python3.11-${PYTHON_VER} python3.11-pip-${PIP_VER} maven-${MAVEN_VER} -y
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as builder
 
 RUN yum install java-17-amazon-corretto python3.11 python3.11-pip maven binutils -y && \
     yum clean all
@@ -21,6 +15,6 @@ RUN /usr/bin/python3.11 -m venv .venv && \
 RUN mv dist/porting-advisor-linux-$(uname -m) /opt/porting-advisor
 
 # Use Amazon Corretto as runtime
-FROM public.ecr.aws/amazoncorretto/amazoncorretto:17.0.7-al2023 as runtime
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:17-al2023 as runtime
 COPY --from=builder /opt/porting-advisor /usr/bin/porting-advisor
 ENTRYPOINT ["/usr/bin/porting-advisor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ COPY . .
 RUN /usr/bin/python3.11 -m venv .venv && \
     source .venv/bin/activate && \
     python3 -m pip install -r requirements-build.txt && \
-    ./build.sh
+    FILE_NAME=porting-advisor ./build.sh
 
-RUN mv dist/porting-advisor-linux-$(uname -m) /opt/porting-advisor
+RUN mv dist/porting-advisor /opt/porting-advisor
 
 # Use Amazon Corretto as runtime
 FROM public.ecr.aws/amazoncorretto/amazoncorretto:17-al2023 as runtime

--- a/Dockerfile-package
+++ b/Dockerfile-package
@@ -1,3 +1,3 @@
-FROM public.ecr.aws/amazoncorretto/amazoncorretto:17.0.7-al2023
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:17-al2023
 COPY ./dist/porting-advisor /usr/bin/porting-advisor
 ENTRYPOINT ["/usr/bin/porting-advisor"]

--- a/Dockerfile-package
+++ b/Dockerfile-package
@@ -1,0 +1,3 @@
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:17.0.7-al2023
+COPY ./dist/porting-advisor /usr/bin/porting-advisor
+ENTRYPOINT ["/usr/bin/porting-advisor"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you run into any issues, see our [CONTRIBUTING](CONTRIBUTING.md#reporting-bug
 
 ## As a container
 
-By using this option, you don't need to worry about Python or Java versions, or any other dependency that the tool needs. This is the quickest way to get started. 
+By using this option, you don't need to worry about Python or Java versions, or any other dependency that the tool needs. This is the quickest way to get started.
 
 **Pre-requisites**
 
@@ -134,6 +134,8 @@ python3 src/porting-advisor.py ~/my/path/to/my/repo --output report.html
 - (Optionally) Open JDK 17 (or above) and Maven 3.5 (or above) if you want the binary to be able to scan JAR files for native methods.
 
 The `build.sh` script will generate a self-contained binary (for Linux/MacOS). It will be output to a folder called `dist`.
+
+By default, it will generate a binary named like `porting-advisor-linux-x86_64`. You can customize generated filename by setting environment variable `FILE_NAME`.
 
 ```bash
 ./build.sh

--- a/README.md
+++ b/README.md
@@ -35,13 +35,45 @@ This is a fork of [Porting advisor](https://github.com/arm-hpc/porting-advisor),
 
 For more information on how to modify issues reported, use the tool’s built-in help:
 
-```
+```bash
 ./porting-advisor-linux-x86_64 -–help
 ```
 
 If you run into any issues, see our [CONTRIBUTING](CONTRIBUTING.md#reporting-bugsfeature-requests) file.
 
 # How to run:
+
+## As a container
+
+By using this option, you don't need to worry about Python or Java versions, or any other dependency that the tool needs. This is the quickest way to get started. 
+
+**Pre-requisites**
+
+- Docker or [containerd](https://github.com/containerd/containerd) + [nerdctl](https://github.com/containerd/nerdctl) + [buildkit](https://github.com/moby/buildkit)
+
+**Build container image**
+
+NOTE: if using containerd, you can substitute `docker` with `nerdctl`
+
+```bash
+docker build -t porting-advisor:latest .
+```
+
+**Run container image**
+
+After building the image, we can run the tool as a container. We use `-v` to mount a volume from our host machine to the container.
+
+We can run it directly to console:
+
+```bash
+docker run -v ~/my/path:/my-path porting-advisor /my-path/src
+```
+
+Or generate a report:
+
+```bash
+docker run -v ~/my/path:/my-path porting-advisor /my-path/src --output /my-path/output/report.html
+```
 
 ## As a Python script
 
@@ -53,30 +85,30 @@ If you run into any issues, see our [CONTRIBUTING](CONTRIBUTING.md#reporting-bug
 **Enable Python Environment**
 
 Linux/Mac:
-```
-$. python3 -m venv .venv
-$. source .venv/bin/activate
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
 ```
 
 Powershell:
-```
-PS> python -m venv .venv
-PS> .\.venv\Scripts\Activate.ps1
+```shell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
 ```
 
 **Install requirements**
-```
-$. pip3 install -r requirements.txt
+```bash
+pip3 install -r requirements.txt
 ```
 
 **Run tool (console output)**
-```
-$. python3 src/porting-advisor.py ~/my/path/to/my/repo
+```bash
+python3 src/porting-advisor.py ~/my/path/to/my/repo
 ```
 
 **Run tool (HTML report)**
-```
-$. python3 src/porting-advisor.py ~/my/path/to/my/repo --output report.html
+```bash
+python3 src/porting-advisor.py ~/my/path/to/my/repo --output report.html
 ```
 
 ## As a binary
@@ -90,14 +122,14 @@ $. python3 src/porting-advisor.py ~/my/path/to/my/repo --output report.html
 
 The `build.sh` script will generate a self-contained binary (for Linux/MacOS). It will be output to a folder called `dist`.
 
-```
-$ ./build.sh
+```bash
+./build.sh
 ```
 
 For Windows, the `Build.ps1` will generate a folder with an EXE and all the files it requires to run.
 
-```
-PS> .\Build.ps1
+```shell
+.\Build.ps1
 ```
 
 **Running the binary**
@@ -107,23 +139,23 @@ PS> .\Build.ps1
 Once you have the binary generated, it will only require Java 11 Runtime (or above) if you want to scan JAR files for native methods. Otherwise, the file is self-contained and doesn't need Python to run.
 
 Default behaviour, console output:
-```
+```bash
 $ ./porting-advisor-linux-x86_64 ~/my/path/to/my/repo
 ```
 
 Generating HTML report:
-```
+```bash
 $ ./porting-advisor-linux-x86_64 ~/my/path/to/my/repo --output report.html
 ```
 
 Generating a report of just dependencies (this creates an Excel file with just the dependencies we found on the repo, no suggestions provided):
-```
+```bash
 $ ./porting-advisor-linux-x86_64 ~/my/path/to/my/repo --output dependencies.xlsx --output-format dependencies
 ```
 
 ### Sample console report output:
 
-```
+```bash
 ./dist/porting-advisor-linux-x86_64 ./sample-projects/
 | Elapsed Time: 0:00:03
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,17 @@ By using this option, you don't need to worry about Python or Java versions, or 
 
 **Build container image**
 
-NOTE: if using containerd, you can substitute `docker` with `nerdctl`
+**NOTE:** if using containerd, you can substitute `docker` with `nerdctl`
 
 ```bash
 docker build -t porting-advisor .
+```
+
+**NOTE:** on Windows you might need to run these commands to avoid bash scripts having their line ends changed to CRLF:
+
+```shell
+git config core.autocrlf false
+git reset --hard
 ```
 
 **Run container image**
@@ -66,13 +73,19 @@ After building the image, we can run the tool as a container. We use `-v` to mou
 We can run it directly to console:
 
 ```bash
-docker run --rm -v ~/my/path:/my-path porting-advisor /my-path/src
+docker run --rm -v my/repo/path:/repo porting-advisor /repo
 ```
 
 Or generate a report:
 
 ```bash
-docker run --rm -v ~/my/path:/my-path porting-advisor /my-path/src --output /my-path/output/report.html
+docker run --rm -v my/repo/path:/repo -v my/output:/output porting-advisor /repo --output /output/report.html
+```
+
+Windows example:
+
+```shell
+docker run --rm -v /c/Users/myuser/repo:/repo -v /c/Users/myuser/output:/output porting-advisor /repo --output /output/report.html
 ```
 
 ## As a Python script

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ By using this option, you don't need to worry about Python or Java versions, or 
 NOTE: if using containerd, you can substitute `docker` with `nerdctl`
 
 ```bash
-docker build -t porting-advisor:latest .
+docker build -t porting-advisor .
 ```
 
 **Run container image**
@@ -66,13 +66,13 @@ After building the image, we can run the tool as a container. We use `-v` to mou
 We can run it directly to console:
 
 ```bash
-docker run -v ~/my/path:/my-path porting-advisor /my-path/src
+docker run --rm -v ~/my/path:/my-path porting-advisor /my-path/src
 ```
 
 Or generate a report:
 
 ```bash
-docker run -v ~/my/path:/my-path porting-advisor /my-path/src --output /my-path/output/report.html
+docker run --rm -v ~/my/path:/my-path porting-advisor /my-path/src --output /my-path/output/report.html
 ```
 
 ## As a Python script

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,12 @@ fi
 
 . .venv/bin/activate
 
-FILE_NAME=`./getBinaryName.sh`
+if [[ -z "${FILE_NAME}" ]]; then
+  FILE_NAME=`./getBinaryName.sh`
+else
+  FILE_NAME="${FILE_NAME}"
+fi
+
 echo "*** Will use $FILE_NAME as name ***"
 
 if hash mvn

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script converts the porting-advisor python code into
 # a x86 or arm64 Linux or Mac binary like a.out.

--- a/container-test.sh
+++ b/container-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 source ./test-helpers.sh
 

--- a/container-test.sh
+++ b/container-test.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+source ./test-helpers.sh
+
+# This script tests container image build and runs a couple of
+# tests against the generated image.
+
+if [ -d ".venv" ]; then
+    mv .venv .venv_temp
+fi
+
+docker build -t porting-advisor .
+if [ $? -ne 0 ]; then
+    echo "**ERROR**: building container image" && exit 1
+fi
+
+echo "Running container on samples to console"
+docker run --rm -v $(pwd)/sample-projects:/source porting-advisor /source > console_test.txt
+test_report 'console' 'console_test.txt' "${lines_to_find[@]}"
+if [ $? -ne 0 ]; then
+    echo "**ERROR**: running container to console" && exit 1
+fi
+rm console_test.txt
+
+echo "Running container on samples to HTML report"
+docker run --rm -v $(pwd):/source porting-advisor /source/sample-projects --output /source/test.html 
+test_report 'html' 'test.html' "${lines_to_find[@]}"
+if [ $? -ne 0 ]; then
+    echo "**ERROR**: running container to html report" && exit 1
+fi
+rm -f test.html
+
+if [ -d ".venv_temp" ]; then
+    mv .venv_temp .venv
+fi
+
+exit 0

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -1,43 +1,9 @@
 #!/bin/bash
 
-function test_line() {
-    reportType=$1
-    result_filename=$2
-    pattern=$3
-    if grep --quiet "$3" "$result_filename"
-    then
-        echo "**PASS** $reportType report has: $pattern"
-    else
-        echo "**FAILED** $reportType report is missing: $pattern" && exit 1
-    fi
-}
-
-function test_report() {
-    report_type=$1
-    shift
-    result_filename=$1
-    shift
-    patterns=("$@")
-    for line in "${patterns[@]}";
-    do
-        test_line $report_type $result_filename "${line[@]}"
-    done
-}
+source ./test-helpers.sh
 
 FILE_NAME=`./getBinaryName.sh`
 chmod +x ./dist/$FILE_NAME
-
-declare -a lines_to_find=("detected java code. we recommend using Corretto"
-                "detected python code. min version 3.7.5 is required"
-                "detected python code. if you need pip, version 19.3 or above is recommended"
-                "dependency library numpy is present. min version 1.19.0 is required"
-                "detected java code. min version 8 is required. version 11 or above is recommended"
-                "using dependency library snappy-java version 1.1.3. upgrade to at least version 1.1.4"
-                "using dependency library hadoop-lzo. this library requires a manual build"
-                "dependency library: leveldbjni-all is not supported on Graviton"
-                "detected go code. min version 1.16 is required. version 1.18 or above is recommended"
-                "using dependency library github.com/golang/snappy version 0.0.1. upgrade to at least version 0.0.2"
-                )
 
 echo "Running samples to console"
 ./dist/$FILE_NAME ./sample-projects/ > console_test.txt

--- a/load_test.sh
+++ b/load_test.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 FILE_NAME=`./getBinaryName.sh`
 chmod +x ./dist/$FILE_NAME
 

--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script sets up the Python Virtual Environment to install dependencies
 

--- a/test-helpers.sh
+++ b/test-helpers.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+function test_line() {
+    reportType=$1
+    result_filename=$2
+    pattern=$3
+    if grep --quiet "$3" "$result_filename"
+    then
+        echo "**PASS** $reportType report has: $pattern"
+    else
+        echo "**FAILED** $reportType report is missing: $pattern" && exit 1
+    fi
+}
+
+function test_report() {
+    report_type=$1
+    shift
+    result_filename=$1
+    shift
+    patterns=("$@")
+    for line in "${patterns[@]}";
+    do
+        test_line $report_type $result_filename "${line[@]}"
+    done
+}
+
+declare -a lines_to_find=("detected java code. we recommend using Corretto"
+    "detected python code. min version 3.7.5 is required"
+    "detected python code. if you need pip, version 19.3 or above is recommended"
+    "dependency library numpy is present. min version 1.19.0 is required"
+    "detected java code. min version 8 is required. version 11 or above is recommended"
+    "using dependency library snappy-java version 1.1.3. upgrade to at least version 1.1.4"
+    "using dependency library hadoop-lzo. this library requires a manual build"
+    "dependency library: leveldbjni-all is not supported on Graviton"
+    "detected go code. min version 1.16 is required. version 1.18 or above is recommended"
+    "using dependency library github.com/golang/snappy version 0.0.1. upgrade to at least version 0.0.2"
+)

--- a/test-helpers.sh
+++ b/test-helpers.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 function test_line() {
     reportType=$1
     result_filename=$2

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Runs unit tests, generates the binary and then runs it against sample projects
 

--- a/test.sh
+++ b/test.sh
@@ -28,3 +28,13 @@ echo "🧪 Running integration tests"
 if [ $? -ne 0 ]; then
     echo "**ERROR**: integration tests failed" && exit 1
 fi
+
+
+if hash docker
+then
+    echo "🐋 Running container tests"
+    ./container-test.sh
+    if [ $? -ne 0 ]; then
+        echo "**ERROR**: error generating jar for Graviton Ready Java tool" && exit 1
+    fi
+fi

--- a/unit-test.sh
+++ b/unit-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "🐍 Making sure Python Virtual Environment is active"
 . .venv/bin/activate


### PR DESCRIPTION
#### Description of change
Add a Dockerfile so user can build self-containing container image. User can use this image on any Linux instance without need of Python or Java runtime. 

#### Issue
#26 

#### PR reviewer notes
This Dockerfile contains multiple runtimes (Python, Java and Maven). I left all install command in Dockerfile so it may be poorly formatted. 

I have built a image and stored in `public.ecr.aws/bingjiao/porting-advisor-for-graviton:main` (x86-64 only)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.