### PR TITLE
Run canary twice a day to prevent false postitive alarm

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
   # Run this once a day to check if everything is still working as expected.
-    - cron: "0 12 * * *"
+    - cron: "0 6,12 * * *"
 
 permissions:
   id-token: write


### PR DESCRIPTION
Since the alarm triggers if a canary isn't run over the period of 1 day, if day 1's canary runs at 12:00 PM and day 2 runs at 12:01 PM, the alarm will trigger. And alarms can't be set to scan more than 1 day.

#### Description of change
[//]: # (What are you trying to fix? What did you change)

Fixing canaries 

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)
https://github.com/aws/porting-advisor-for-graviton/issues/28

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.