### PR TITLE
setup-environment.sh isn't using python3.10 or higher even if it is available in PATH while creating PAG binary

### DIFF
--- a/Setup-Environment.ps1
+++ b/Setup-Environment.ps1
@@ -4,9 +4,17 @@ Sets up Python Virtual Environment.
 #>
 
 try {
-    $p = python --version
+    Get-Command python | ForEach-Object {
+        $PYTHON_VERSION_MAJOR = [int]($_.FileVersionInfo.ProductVersion -split '\.')[0]
+        $PYTHON_VERSION_MINOR = [int]($_.FileVersionInfo.ProductVersion -split '\.')[1]
+
+        if ($PYTHON_VERSION_MAJOR -ge 3 -and $PYTHON_VERSION_MINOR -ge 10) {
+            $PYTHON3 = $_.Name
+        }
+    }
+    $p = & $PYTHON3 "--version"
 } catch {
-    throw '**ERROR**: python is missing, please install it before running this build script'
+    throw '**ERROR**: python3.10+ is missing, please install it before running this build script'
 }
 
 try {
@@ -17,7 +25,7 @@ try {
 
 if (!(Test-Path -Path .venv)) {
     Write-Host "💻 Creating Python virtual environment"
-    python -m venv .venv
+    & $PYTHON3 "-m" "venv" ".venv"
     if($LASTEXITCODE -ne 0) {
         throw "**ERROR**: could not create Python Virtual Environment."
     }
@@ -34,3 +42,4 @@ pip install -r requirements-build.txt
 if($LASTEXITCODE -ne 0) {
     throw "**ERROR**: error installing required packages"
 }
+

--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
-# This script sets up the Python Virtual Environment to install dependencies
+# This script looks up Python 3.10 or higher in PATH and sets up the Python Virtual Environment to install dependencies
 
-if hash python3
+for AVAILABLE_PYTHON in $(compgen -c python | sort -u); do
+    PYTHON_VERSION_MAJOR=$($AVAILABLE_PYTHON --version 2>/dev/null | awk -F '[ .]' 'BEGIN {OFS="."} {print $(NF-2)}')
+    PYTHON_VERSION_MINOR=$($AVAILABLE_PYTHON --version 2>/dev/null | awk -F '[ .]' 'BEGIN {OFS="."} {print $(NF-1)}')
+    if [[ $PYTHON_VERSION_MAJOR -ge 3 ]] && [[ $PYTHON_VERSION_MINOR -ge 10 ]]; then
+	    PYTHON3=$AVAILABLE_PYTHON
+	    echo "🐍 python3.10+ is installed"
+   	  break
+    fi
+done
+
+if [[ ! -z $PYTHON3 ]]
 then
-    echo "🐍 python3 is installed"
-
     if hash pip3
     then
         echo "📦 pip is installed"
@@ -15,7 +23,7 @@ then
 
     if [ ! -f ".venv/bin/activate" ]; then
         echo "💻 Creating Python virtual environment"
-        python3 -m venv .venv
+        $PYTHON3 -m venv .venv
         if [ $? -ne 0 ]; then
             echo "**ERROR**: could not create Python Virtual Environment." && exit 1
         fi
@@ -28,12 +36,13 @@ then
     fi
     
     echo "☁️ Installing requirements"
-    python3 -m pip install -r requirements-build.txt
+    $PYTHON3 -m pip install -r requirements-build.txt
     if [ $? -ne 0 ]; then
         echo "**ERROR**: error installing required packages" && exit 1
     fi
     exit 0
 else
-    echo "**ERROR**: python3 is missing, please install it before running this build script"
+    echo "**ERROR**: python3.10+ is missing, please install it before running this build script"
     exit 1
 fi
+


### PR DESCRIPTION
While trying to create binary for the PAG, I get into errors. When I run "setup-environment.sh" in debug mode (bash -x), I see that it usages default Python version on the instance (python 3.9 in case of Amazon Linux 2023) even if a newer python version (3.11) is available in PATH.

#### Description of change
[//]: # Added a code block in `setup-environment.sh` file to list available python version in PATH and loop through each of it, check if it's version is >=3.10 and use that that as python binary in rest of the script. If none of the python version is >=3.10, throw error.

#### Issue
[//]: #32

#### PR reviewer notes
[//]: # NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.