### PR TITLE
rules: Update go.json with ArgoCD minVersion

### DIFF
--- a/src/advisor/rules/go.json
+++ b/src/advisor/rules/go.json
@@ -8,6 +8,7 @@
         "recommendedVersion": "1.18"
     },
     "libraryRules": [
-        { "name": "github.com/golang/snappy", "minVersion": "0.0.2" }
+        { "name": "github.com/golang/snappy", "minVersion": "0.0.2" },
+        { "name": "github.com/argoproj/argo-cd/v2", "minVersion": "2.4.0" }
     ]
 }


### PR DESCRIPTION
See https://github.com/argoproj/argo-cd/releases/tag/v2.4.0

#### Description of change
[//]: # (What are you trying to fix? What did you change)

I added the minimum version of ArgoCD as per their release notes here - https://github.com/argoproj/argo-cd/releases/tag/v2.4.0

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)

https://github.com/aws/porting-advisor-for-graviton/issues/41

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.