### PR TITLE
GitHub actions - Build Release Binaries 

### DIFF
--- a/.github/workflows/build_release_binaries.yml
+++ b/.github/workflows/build_release_binaries.yml
@@ -1,0 +1,91 @@
+name: Build Release Binaries
+on:
+  release:
+    types:
+      - published
+    branches: 
+    - main
+    - release/*
+jobs:
+
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest", "macos-latest"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Run build 
+      run: |
+        ./build.sh
+
+    - name: Create tar/gzip file
+      run: |
+         tar czvf porting-advisor-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tar.gz -C dist .
+         ls -l *.tar.gz
+
+    - name: Upload Release Asset
+      if: matrix.os != 'windows-latest'
+      id: upload-release-asset-release-ubuntu-mac
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: porting-advisor-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tar.gz
+        asset_name: porting-advisor-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.tar.gz
+        asset_content_type: application/gzip
+
+
+  build-windows:
+    
+    runs-on: "windows-latest"
+  
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Run build
+      run: |
+        .\Build.ps1
+        
+    - name: Create zip file
+      run: |
+        Compress-Archive -Path dist/* -DestinationPath  porting-advisor-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.zip
+        dir *.zip
+          
+    - name: Upload Release Asset
+      id: upload-release-asset-release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: porting-advisor-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.zip
+        asset_name: porting-advisor-${{github.ref_name}}-${{runner.os}}-${{runner.arch}}.zip
+        asset_content_type: application/zip

--- a/.github/workflows/build_release_binaries.yml
+++ b/.github/workflows/build_release_binaries.yml
@@ -6,6 +6,10 @@ on:
     branches: 
     - main
     - release/*
+
+permissions:
+  contents: write
+  
 jobs:
 
   build:


### PR DESCRIPTION
#### Description of change
Created a git hub action event based on 'release' to build binaries and upload it to the Release Artifacts

#### Notes
Upon creation/publication of a Release, the build release binary will create and upload a Windows, Mac, and Ubuntu binary.

#### Issue
Resolves #40