### PR TITLE
add a Python version check when running as a script

### DIFF
--- a/src/porting-advisor.py
+++ b/src/porting-advisor.py
@@ -16,8 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+import sys
 
 from advisor import main
 
 if __name__ == '__main__':
+    if sys.version_info < (3, 10):
+        print("Python 3.10 or newer is required to run this application.")
+        sys.exit(1)
     main()


### PR DESCRIPTION
#### Description of change
[//]: # (What are you trying to fix? What did you change)
When running as a script, even on current AL2/AL2023 porting advisor fails with an exception due to old Python version installed by default. This change will print a descriptive message in such cases which will help users who missed the prerequisite in the Readme.md

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)
#48 

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.