### PR TITLE
Updating dependencies cetifi and lombok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ dependencies.xlsx
 *.jar
 
 temp/
+
+.DS_Store

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,5 @@
 altgraph==0.17.3
-certifi==2023.7.22
+certifi==2024.7.4
 coverage==7.2.7
 idna==3.7
 Jinja2==3.1.4

--- a/src/advisor/tools/graviton-ready-java/pom.xml
+++ b/src/advisor/tools/graviton-ready-java/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.22</version>
+      <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
#### Description of change
This updates a change from DependaBot here: https://github.com/aws/porting-advisor-for-graviton/pull/62
And also fixes the issue described here: https://github.com/aws/porting-advisor-for-graviton/issues/63 

Also updated gitignore to ignore all .DS_Store files

#### Issue
[//]: # (Having an issue # for the PR is required for tracking purposes. If an existing issue does not exist please create one.)
https://github.com/aws/porting-advisor-for-graviton/issues/63

#### PR reviewer notes
[//]: # (Let us know if there is anything we should focus on.)
Tested with:
`./build.sh`
`./test.sh`
`./integration-test.sh`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.