### PR TITLE
Fix/python update

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     
     - name: Set up JDK 11
       uses: actions/setup-java@v3
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     
     - name: Set up JDK 11
       uses: actions/setup-java@v3

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     
     - name: Set up JDK 11
       uses: actions/setup-java@v3
@@ -86,7 +86,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     
     - name: Set up JDK 11
       uses: actions/setup-java@v3


### PR DESCRIPTION
#### Description of change
[//]: # (What are you trying to fix? What did you change)

This pull request updates the Python version used in the CI pipeline from 3.10 to 3.12. The change is necessary to resolve an issue with the `ipaddress` module not being found, which was fixed in PyInstaller for Python versions 3.11 and above.

Specifically, this update addresses the problem that arose when GitHub Actions runner OS was updated to the latest version, as documented in https://github.com/actions/runner-images/issues/10636.

The fix for the `ipaddress` module issue is implemented in PyInstaller's pull request: https://github.com/pyinstaller/pyinstaller/pull/7694

#### Issue
#68 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
